### PR TITLE
Do not add #undefined to the end of URL after redirect

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -580,7 +580,7 @@ export class OAuth2AuthCodePKCE {
     const [urlPart, queryStringAndHashUrlPart] = url.split('?');
     // @ts-ignore
     const [_queryParamsPart, hashUrlPart] = queryStringAndHashUrlPart.split('#');
-    return `${urlPart}#${hashUrlPart}`;
+    return `${urlPart}${hashUrlPart !== undefined ? `#${hashUrlPart}` : ''}`;
   }
 
   /**


### PR DESCRIPTION
This checks to see if the redirect URL actually had a hash URL before trying
to append it to the cleaned-up URL.