### PR TITLE
Add client id and refresh token in refresh token request

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -358,7 +358,8 @@ export class OAuth2AuthCodePKCE {
 
     const url = tokenUrl;
     const body = `grant_type=refresh_token&`
-      + `refresh_token=${refreshToken}`;
+      + `refresh_token=${refreshToken ? refreshToken.value : null}&`
+      + `client_id=${this.config.clientId}`;
 
     return fetch(url, {
       method: 'POST',


### PR DESCRIPTION
The refresh token request is sending that [object Object].

We should also include the client id right?