### PR TITLE
Include support for openid

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -276,10 +276,14 @@ export class OAuth2AuthCodePKCE {
    * Fetch an authorization grant via redirection. In a sense this function
    * doesn't return because of the redirect behavior (uses `location.replace`).
    */
-  public async fetchAuthorizationCode(): Promise<void> {
+  public async fetchAuthorizationCode(oneTimeParams: ObjStringDict = {}): Promise<void> {
     this.assertStateAndConfigArePresent();
 
-    const { clientId, redirectUrl, scopes, extraAuthorizeParams } = this.config;
+    const { clientId, redirectUrl, scopes } = this.config;
+    const extraAuthorizeParams: ObjStringDict = {
+      ...this.config.extraAuthorizeParams,
+      ...oneTimeParams
+    };
     const { codeChallenge, codeVerifier } = await OAuth2AuthCodePKCE
       .generatePKCECodes();
     const stateQueryParam = OAuth2AuthCodePKCE


### PR DESCRIPTION
My patch discussed in [this issue](https://github.com/BitySA/oauth2-auth-code-pkce/issues/5) has now been stable for a few weeks and has been working well.

This adds a config option to explicitly expose any tokens besides the access token (namely, the `id_token`) and config options for extra parameters to pass to the authorize and refresh routes (In my case, auth0 needed the `client_id` for the refresh route, and I needed to be able to specify an `audience` during the initial authorization).