### PR TITLE
Add client_id in refresh token request

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -347,7 +347,7 @@ export class OAuth2AuthCodePKCE {
   public exchangeRefreshTokenForAccessToken(): Promise<AccessContext> {
     this.assertStateAndConfigArePresent();
 
-    const { onInvalidGrant, tokenUrl } = this.config;
+    const { onInvalidGrant, tokenUrl, clientId } = this.config;
     const { refreshToken } = this.state;
 
     if (!refreshToken) {
@@ -356,7 +356,8 @@ export class OAuth2AuthCodePKCE {
 
     const url = tokenUrl;
     const body = `grant_type=refresh_token&`
-      + `refresh_token=${refreshToken?.value}`;
+      + `refresh_token=${refreshToken?.value}&`
+      + `client_id=${clientId}`;
 
     return fetch(url, {
       method: 'POST',


### PR DESCRIPTION
Quotes from rfc6749:

>  6. Refreshing an Access Token (https://tools.ietf.org/html/rfc6749#section-6)
> ...
> If the client type is confidential or
>    the client was issued client credentials (**or assigned other**
>    **authentication requirements**), the client MUST authenticate with the
>    authorization server as described in Section 3.2.1 (https://tools.ietf.org/html/rfc6749#section-3.2.1).

and

> 3.2.1.  Client Authentication
> ...
>  A client MAY use the "client_id" request parameter to identify itself
>    when sending requests to the token endpoint. 

Well-known server implementations expect parameter `client_id` for verify a refresh_token request. Can we include a `client_id` in request?